### PR TITLE
feat(address-list): 添加`删除`按钮

### DIFF
--- a/src/address-list/Item.tsx
+++ b/src/address-list/Item.tsx
@@ -25,6 +25,7 @@ export type AddressItemEvents = {
   onEdit(): void;
   onClick(): void;
   onSelect(): void;
+  onDelete(): void;
 };
 
 const [createComponent, bem] = createNamespace('address-item');
@@ -46,15 +47,28 @@ function AddressItem(
   }
 
   const renderRightIcon = () => (
-    <Icon
-      name="edit"
-      class={bem('edit')}
-      onClick={(event: Event) => {
-        event.stopPropagation();
-        emit(ctx, 'edit');
-        emit(ctx, 'click');
-      }}
-    />
+    <div class={bem('icons')}>
+      <span class={bem('icons-wrapper')}>
+        <Icon
+          name="edit"
+          class={bem('edit')}
+          onClick={(event: Event) => {
+            event.stopPropagation();
+            emit(ctx, 'edit');
+            emit(ctx, 'click');
+          }}
+        />
+        <Icon
+          name="delete"
+          class={bem('delete')}
+          onClick={(event: Event) => {
+            event.stopPropagation();
+            emit(ctx, 'delete');
+            emit(ctx, 'click');
+          }}
+        />
+      </span>
+    </div>
   );
 
   const renderContent = () => {

--- a/src/address-list/Item.tsx
+++ b/src/address-list/Item.tsx
@@ -47,8 +47,8 @@ function AddressItem(
   }
 
   const renderRightIcon = () => (
-    <div class={bem('icons')}>
-      <span class={bem('icons-wrapper')}>
+    <div class={bem('icons-wrapper')}>
+      <span class={bem('icons-group')}>
         <Icon
           name="edit"
           class={bem('edit')}

--- a/src/address-list/README.zh-CN.md
+++ b/src/address-list/README.zh-CN.md
@@ -21,6 +21,7 @@ Vue.use(AddressList);
   disabled-text="以下地址超出配送范围"
   @add="onAdd"
   @edit="onEdit"
+  @delete="onDelete"
 />
 ```
 
@@ -61,6 +62,10 @@ export default {
 
     onEdit(item, index) {
       Toast('编辑地址:' + index);
+    },
+
+    onDelete(item, index) {
+      Toast('删除地址:' + index)
     }
   }
 }
@@ -85,6 +90,7 @@ export default {
 |------|------|------|------|
 | add | 点击新增按钮时触发 | - |
 | edit | 点击编辑按钮时触发 | item: 地址对象，index: 索引 |
+| delete | 点击删除按钮时触发 | item: 地址对象，index: 索引 |
 | select | 切换选中的地址时触发 | item: 地址对象，index: 索引 |
 | edit-disabled | 编辑不可配送的地址时触发 | item: 地址对象，index: 索引 |
 | select-disabled | 选中不可配送的地址时触发 | item: 地址对象，index: 索引 |

--- a/src/address-list/demo/index.vue
+++ b/src/address-list/demo/index.vue
@@ -8,6 +8,7 @@
         :disabled-text="$t('disabledText')"
         @add="onAdd"
         @edit="onEdit"
+        @delete="onDelete"
       />
     </demo-block>
   </demo-section>
@@ -85,6 +86,10 @@ export default {
 
     onEdit(item, index) {
       this.$toast(`${this.$t('edit')}:${index}`);
+    },
+
+    onDelete(item, index) {
+      this.$toast(`${this.$t('delete')}:${index}`);
     }
   }
 };

--- a/src/address-list/index.less
+++ b/src/address-list/index.less
@@ -47,11 +47,11 @@
     }
   }
 
-  &__icons {
+  &__icons-wrapper {
     margin-left: @padding-md;
   }
 
-  &__icons-wrapper {
+  &__icons-group {
     position: absolute;
     top: 50%;
     right: @padding-md;

--- a/src/address-list/index.less
+++ b/src/address-list/index.less
@@ -47,12 +47,20 @@
     }
   }
 
-  &__edit {
+  &__icons {
+    margin-left: @padding-md;
+  }
+
+  &__icons-wrapper {
     position: absolute;
     top: 50%;
     right: @padding-md;
     font-size: @address-list-edit-icon-size;
     transform: translate(0, -50%);
+  }
+
+  &__edit {
+    margin-right: 10px;
   }
 
   .van-radio__icon--checked .van-icon {

--- a/src/address-list/index.tsx
+++ b/src/address-list/index.tsx
@@ -53,6 +53,9 @@ function AddressList(
         onClick={() => {
           emit(ctx, 'click-item', item, index);
         }}
+        onDelete={() => {
+          emit(ctx, 'delete', item, index)
+        }}
       />
     ));
   }

--- a/src/address-list/test/__snapshots__/demo.spec.js.snap
+++ b/src/address-list/test/__snapshots__/demo.spec.js.snap
@@ -11,8 +11,8 @@ exports[`renders demo correctly 1`] = `
               <div class="van-radio__icon van-radio__icon--round van-radio__icon--checked" style="font-size: 16px;"><i class="van-icon van-icon-success">
                   <!----></i></div><span class="van-radio__label"><div class="van-address-item__name">张三，13000000000</div><div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div></span>
             </div>
-          </div><i class="van-icon van-icon-edit van-address-item__edit">
-            <!----></i>
+          </div>
+          <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
         </div>
         <div role="button" tabindex="0" class="van-cell van-cell--clickable van-address-item">
           <div class="van-cell__value van-cell__value--alone van-address-item__value">
@@ -20,8 +20,8 @@ exports[`renders demo correctly 1`] = `
               <div class="van-radio__icon van-radio__icon--round" style="font-size: 16px;"><i class="van-icon van-icon-success">
                   <!----></i></div><span class="van-radio__label"><div class="van-address-item__name">李四，1310000000</div><div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div></span>
             </div>
-          </div><i class="van-icon van-icon-edit van-address-item__edit">
-            <!----></i>
+          </div>
+          <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
         </div>
       </div>
       <div class="van-address-list__disabled-text">以下地址超出配送范围</div>
@@ -29,8 +29,8 @@ exports[`renders demo correctly 1`] = `
         <div class="van-cell__value van-cell__value--alone van-address-item__value">
           <div class="van-address-item__name">王五，1320000000</div>
           <div class="van-address-item__address">浙江省杭州市滨江区江南大道 15 号</div>
-        </div><i class="van-icon van-icon-edit van-address-item__edit">
-          <!----></i>
+        </div>
+        <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
       </div><button class="van-button van-button--danger van-button--large van-button--square van-address-list__add"><span class="van-button__text">新增地址</span></button>
     </div>
   </div>

--- a/src/address-list/test/__snapshots__/index.spec.js.snap
+++ b/src/address-list/test/__snapshots__/index.spec.js.snap
@@ -7,15 +7,15 @@ exports[`unswitchable 1`] = `
       <div class="van-cell__value van-cell__value--alone van-address-item__value">
         <div class="van-address-item__name">张三，13000000000</div>
         <div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div>
-      </div><i class="van-icon van-icon-edit van-address-item__edit">
-        <!----></i>
+      </div>
+      <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
     </div>
     <div class="van-cell van-address-item">
       <div class="van-cell__value van-cell__value--alone van-address-item__value">
         <div class="van-address-item__name">李四，1310000000</div>
         <div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div>
-      </div><i class="van-icon van-icon-edit van-address-item__edit">
-        <!----></i>
+      </div>
+      <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
     </div>
   </div><button class="van-button van-button--danger van-button--large van-button--square van-address-list__add"><span class="van-button__text">新增地址</span></button>
 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3160,7 +3160,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npm.taobao.org/debuglog/download/debuglog-1.0.1.tgz?cache=0&sync_timestamp=1571025488443&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fdebuglog%2Fdownload%2Fdebuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -5151,7 +5151,7 @@ import-local@2.0.0, import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -6519,10 +6519,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.npm.taobao.org/lodash._baseindexof/download/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.npm.taobao.org/lodash._baseuniq/download/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6530,27 +6526,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.npm.taobao.org/lodash._bindcallback/download/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.npm.taobao.org/lodash._cacheindexof/download/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.npm.taobao.org/lodash._createcache/download/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.npm.taobao.org/lodash._createset/download/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.npm.taobao.org/lodash._getnative/download/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6575,10 +6553,6 @@ lodash.kebabcase@^4.1.1:
 lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.npm.taobao.org/lodash.restparam/download/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.sortby@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
## Why

- 业务需求, 可在地址列表页删除地址功能

## How

- 在编辑右侧增加删除按钮, 图标使用youzan自身提供的[垃圾桶]
- 使用方式 `@delete`, 类似于 `@edit`

## Animated Screenshot

![address-del](https://user-images.githubusercontent.com/53422750/67074051-efbf1800-f1ba-11e9-9628-1f61f8cb763f.gif)

## Test

```diff
$ jest src/address-list/
+  PASS  src/address-list/test/index.spec.js
+  PASS  src/address-list/test/demo.spec.js

=============================== Coverage summary ===============================
- Statements   : 14.23% ( 432/3036 )
- Branches     : 6.71% ( 152/2264 )
- Functions    : 9.31% ( 88/945 )
- Lines        : 14.39% ( 427/2967 )
================================================================================

+ Test Suites: 2 passed, 2 total
+ Tests:       4 passed, 4 total
+ Snapshots:   2 passed, 2 total
+ Time:        14.16s, estimated 26s
Ran all test suites matching /src\/address-list\//i.
```

## Docs

- address-list(地址列表) zh-CN
  - 更新 demo
  - event 添加 delete 说明