### PR TITLE
chore: run lint

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=http://levy.ren:4873

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=http://levy.ren:4873

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "bootstrap": "yarn || npm i",
     "dev": "npm run build:entry && webpack-dev-server --config build/webpack.site.dev.js",
-    "lint": "eslint ./src --ext .js,.vue,.ts,.tsx && stylelint \"src/**/*.less\" --fix",
+    "lint": "eslint ./src --ext .js,.vue,.ts,.tsx --fix && stylelint \"src/**/*.less\" --fix",
     "build:entry": "node build/build-entry.js",
     "build:changelog": "vant changelog ./docs/markdown/changelog.generated.md --tag v2.1.0",
     "build:lib": "node build/build-lib.js",

--- a/src/address-list/index.tsx
+++ b/src/address-list/index.tsx
@@ -54,7 +54,7 @@ function AddressList(
           emit(ctx, 'click-item', item, index);
         }}
         onDelete={() => {
-          emit(ctx, 'delete', item, index)
+          emit(ctx, 'delete', item, index);
         }}
       />
     ));


### PR DESCRIPTION
## Why

运行 lint 修复缺失的 `;`

## Test

```console
$ eslint ./src --ext .js,.vue,.ts,.tsx --fix && stylelint "src/**/*.less" --fix
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0

YOUR TYPESCRIPT VERSION: 3.6.3

Please only submit bug reports when using the officially supported version.

=============
✨  Done in 54.03s.
```