### PR TITLE
feat(search): enhance search input for iOS

### DIFF
--- a/src/search/README.md
+++ b/src/search/README.md
@@ -37,6 +37,7 @@ export default {
     show-action
     @search="onSearch"
     @cancel="onCancel"
+    :remove-form="true"
   />
 </form>
 ```

--- a/src/search/README.md
+++ b/src/search/README.md
@@ -78,6 +78,7 @@ Search support all native properties of input tag，such as `maxlength`、`place
 | input-align | Text align of field, can be set to `center` `right` | *string* | `left` | - |
 | left-icon | Left icon name | *string* | `search` | - |
 | right-icon | Right icon name | *string* | - | - |
+| removeForm | render component without form element | *boolean* | `false` | - |
 
 ### Events
 

--- a/src/search/README.md
+++ b/src/search/README.md
@@ -30,7 +30,7 @@ export default {
 `search` event will be triggered when click the search button on the keyboard, `cancel` event will be triggered when click the cancel button.
 
 ```html
-<form action="/">
+<form action="javascript:;">
   <van-search
     v-model="value"
     placeholder="Placeholder"

--- a/src/search/README.md
+++ b/src/search/README.md
@@ -42,7 +42,7 @@ export default {
 </form>
 ```
 
-> Tips: There will be a search button on the keyboard when Search is inside a form in iOS.
+> Tips: Set props remove-from into true if you want to nest van-search with other input in same form tag
 
 ### Custom Action Button
 

--- a/src/search/README.zh-CN.md
+++ b/src/search/README.zh-CN.md
@@ -73,6 +73,7 @@ Search 默认支持 Input 标签所有的原生属性，比如 `maxlength`、`pl
 | input-align | 输入框内容对齐方式，可选值为 `center` `right` | *string* | `left` | - |
 | left-icon | 输入框左侧图标名称或图片链接，可选值见 [Icon 组件](/#/zh-CN/icon) | *string* | `search` | - |
 | right-icon | 输入框右侧图标名称或图片链接，可选值见 [Icon 组件](/#/zh-CN/icon) | *string* | - | - |
+| removeForm | 取消默认 form 元素嵌套，默认嵌套 form。在 iOS 下显示「搜索」按钮 | *boolean* | `false` | - |
 
 ### Events
 

--- a/src/search/README.zh-CN.md
+++ b/src/search/README.zh-CN.md
@@ -31,6 +31,7 @@ Search 组件提供了`search`和`cancel`事件，`search`事件在点击键盘�
     show-action
     @search="onSearch"
     @cancel="onCancel"
+    :remove-form="true"
   />
 </form>
 ```

--- a/src/search/README.zh-CN.md
+++ b/src/search/README.zh-CN.md
@@ -36,7 +36,7 @@ Search 组件提供了`search`和`cancel`事件，`search`事件在点击键盘�
 </form>
 ```
 
-> Tips: 在 van-search 外层增加 form 标签，且 action 不为空，即可在 iOS 输入法中显示搜索按钮
+> Tips: 如果你希望 van-search 和其他表单项嵌套在同一个 from 标签下，可以设置属性 remove-form 为 true
 
 ### 自定义按钮
 

--- a/src/search/README.zh-CN.md
+++ b/src/search/README.zh-CN.md
@@ -24,7 +24,7 @@ v-model 用于控制搜索框中的文字，background 可以自定义搜索框�
 Search 组件提供了`search`和`cancel`事件，`search`事件在点击键盘上的搜索/回车按钮后触发，`cancel`事件在点击搜索框右侧取消按钮时触发
 
 ```html
-<form action="/">
+<form action="javascript:;">
   <van-search
     v-model="value"
     placeholder="请输入搜索关键词"

--- a/src/search/demo/index.vue
+++ b/src/search/demo/index.vue
@@ -12,6 +12,7 @@
           show-action
           @search="onSearch"
           @cancel="onCancel"
+          :remove-form="true"
         />
       </form>
     </demo-block>

--- a/src/search/index.tsx
+++ b/src/search/index.tsx
@@ -69,15 +69,6 @@ function Search(
     );
   }
 
-  function WithForm(component: CreateElement) {
-    // 在 input 外层增加 form 标签，且 action 不为空，同时 input 的 type 为 search，即可在 iOS 输入法中显示搜索按钮。
-    return (
-      <form action="/">
-        {component()}
-      </form>
-    );
-  }
-
   const fieldData = {
     attrs: ctx.data.attrs,
     on: {
@@ -128,7 +119,13 @@ function Search(
     return SearchInput();
   }
 
-  return WithForm(SearchInput);
+  return (
+    // 在 input 外层增加 form 标签，且 action 不为空，同时 input 的 type 为 search，即可在 iOS 输入法中显示搜索按钮。
+    // eslint-disable-next-line
+    <form action="javascript:;">
+      {SearchInput()}
+    </form>
+  );
 }
 
 Search.props = {

--- a/src/search/index.tsx
+++ b/src/search/index.tsx
@@ -19,6 +19,7 @@ export type SearchProps = {
   background: string;
   actionText?: string;
   showAction?: boolean;
+  removeForm?: boolean;
 };
 
 export type SearchSlots = DefaultSlots & {
@@ -68,6 +69,14 @@ function Search(
     );
   }
 
+  function Withform(component: CreateElement) {
+    return (
+      <form action="/">
+        {component()}
+      </form>
+    );
+  }
+
   const fieldData = {
     attrs: ctx.data.attrs,
     on: {
@@ -86,31 +95,39 @@ function Search(
   const inheritData = inherit(ctx);
   delete inheritData.attrs;
 
-  return (
-    <div
-      class={bem({ 'show-action': props.showAction })}
-      style={{ background: props.background }}
-      {...inheritData}
-    >
-      <div class={bem('content', props.shape)}>
-        {Label()}
-        <Field
-          type="search"
-          border={false}
-          value={props.value}
-          leftIcon={props.leftIcon}
-          rightIcon={props.rightIcon}
-          clearable={props.clearable}
-          scopedSlots={{
-            'left-icon': slots['left-icon'],
-            'right-icon': slots['right-icon']
-          }}
-          {...fieldData}
-        />
+  function SearchInput() {
+    return (
+      <div
+        class={bem({ 'show-action': props.showAction })}
+        style={{ background: props.background }}
+        {...inheritData}
+      >
+        <div class={bem('content', props.shape)}>
+          {Label()}
+          <Field
+            type="search"
+            border={false}
+            value={props.value}
+            leftIcon={props.leftIcon}
+            rightIcon={props.rightIcon}
+            clearable={props.clearable}
+            scopedSlots={{
+              'left-icon': slots['left-icon'],
+              'right-icon': slots['right-icon']
+            }}
+            {...fieldData}
+          />
+        </div>
+        {Action()}
       </div>
-      {Action()}
-    </div>
-  );
+    );
+  }
+
+  if (props.removeForm) {
+    return SearchInput();
+  }
+
+  return Withform(SearchInput);
 }
 
 Search.props = {
@@ -134,6 +151,10 @@ Search.props = {
   leftIcon: {
     type: String,
     default: 'search'
+  },
+  removeForm: {
+    type: Boolean,
+    default: false
   }
 };
 

--- a/src/search/index.tsx
+++ b/src/search/index.tsx
@@ -69,7 +69,8 @@ function Search(
     );
   }
 
-  function Withform(component: CreateElement) {
+  function WithForm(component: CreateElement) {
+    // 在 input 外层增加 form 标签，且 action 不为空，同时 input 的 type 为 search，即可在 iOS 输入法中显示搜索按钮。
     return (
       <form action="/">
         {component()}
@@ -127,7 +128,7 @@ function Search(
     return SearchInput();
   }
 
-  return Withform(SearchInput);
+  return WithForm(SearchInput);
 }
 
 Search.props = {

--- a/src/search/test/__snapshots__/demo.spec.js.snap
+++ b/src/search/test/__snapshots__/demo.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`renders demo correctly 1`] = `
 <div>
   <div>
-    <form action="/">
+    <form action="javascript:;">
       <div class="van-search" style="background: rgb(255, 255, 255);">
         <div class="van-search__content van-search__content--square">
           <div class="van-cell van-cell--borderless van-field">
@@ -34,7 +34,7 @@ exports[`renders demo correctly 1`] = `
     </form>
   </div>
   <div>
-    <form action="/">
+    <form action="javascript:;">
       <div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
         <div class="van-search__content van-search__content--round">
           <div class="van-search__label">地址</div>

--- a/src/search/test/__snapshots__/demo.spec.js.snap
+++ b/src/search/test/__snapshots__/demo.spec.js.snap
@@ -3,17 +3,19 @@
 exports[`renders demo correctly 1`] = `
 <div>
   <div>
-    <div class="van-search" style="background: rgb(255, 255, 255);">
-      <div class="van-search__content van-search__content--square">
-        <div class="van-cell van-cell--borderless van-field">
-          <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-              <!----></i></div>
-          <div class="van-cell__value van-cell__value--alone">
-            <div class="van-field__body"><input type="search" placeholder="请输入搜索关键词" class="van-field__control"></div>
+    <form action="/">
+      <div class="van-search" style="background: rgb(255, 255, 255);">
+        <div class="van-search__content van-search__content--square">
+          <div class="van-cell van-cell--borderless van-field">
+            <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+                <!----></i></div>
+            <div class="van-cell__value van-cell__value--alone">
+              <div class="van-field__body"><input type="search" placeholder="请输入搜索关键词" class="van-field__control"></div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </form>
   </div>
   <div>
     <form action="/">
@@ -32,21 +34,23 @@ exports[`renders demo correctly 1`] = `
     </form>
   </div>
   <div>
-    <div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
-      <div class="van-search__content van-search__content--round">
-        <div class="van-search__label">地址</div>
-        <div class="van-cell van-cell--borderless van-field">
-          <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-              <!----></i></div>
-          <div class="van-cell__value van-cell__value--alone">
-            <div class="van-field__body"><input type="search" placeholder="请输入搜索关键词" class="van-field__control"></div>
+    <form action="/">
+      <div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
+        <div class="van-search__content van-search__content--round">
+          <div class="van-search__label">地址</div>
+          <div class="van-cell van-cell--borderless van-field">
+            <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+                <!----></i></div>
+            <div class="van-cell__value van-cell__value--alone">
+              <div class="van-field__body"><input type="search" placeholder="请输入搜索关键词" class="van-field__control"></div>
+            </div>
           </div>
         </div>
+        <div role="button" tabindex="0" class="van-search__action">
+          <div>搜索</div>
+        </div>
       </div>
-      <div role="button" tabindex="0" class="van-search__action">
-        <div>搜索</div>
-      </div>
-    </div>
+    </form>
   </div>
 </div>
 `;

--- a/src/search/test/__snapshots__/index.spec.js.snap
+++ b/src/search/test/__snapshots__/index.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`action-text prop 1`] = `
-<form action="/">
+<form action="javascript:;">
   <div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
     <div class="van-search__content van-search__content--square">
       <div class="van-cell van-cell--borderless van-field">
@@ -18,7 +18,7 @@ exports[`action-text prop 1`] = `
 `;
 
 exports[`label slot 1`] = `
-<form action="/">
+<form action="javascript:;">
   <div class="van-search" style="background: rgb(255, 255, 255);">
     <div class="van-search__content van-search__content--square">
       <div class="van-search__label">Custom Label</div>
@@ -35,7 +35,7 @@ exports[`label slot 1`] = `
 `;
 
 exports[`left-icon prop 1`] = `
-<form action="/">
+<form action="javascript:;">
   <div class="van-search" style="background: rgb(255, 255, 255);">
     <div class="van-search__content van-search__content--square">
       <div class="van-cell van-cell--borderless van-field">
@@ -51,7 +51,7 @@ exports[`left-icon prop 1`] = `
 `;
 
 exports[`right-icon prop 1`] = `
-<form action="/">
+<form action="javascript:;">
   <div class="van-search" style="background: rgb(255, 255, 255);">
     <div class="van-search__content van-search__content--square">
       <div class="van-cell van-cell--borderless van-field">
@@ -70,7 +70,7 @@ exports[`right-icon prop 1`] = `
 `;
 
 exports[`right-icon slot 1`] = `
-<form action="/">
+<form action="javascript:;">
   <div class="van-search" style="background: rgb(255, 255, 255);">
     <div class="van-search__content van-search__content--square">
       <div class="van-cell van-cell--borderless van-field">

--- a/src/search/test/__snapshots__/index.spec.js.snap
+++ b/src/search/test/__snapshots__/index.spec.js.snap
@@ -1,78 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`action-text prop 1`] = `
-<div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
-  <div class="van-search__content van-search__content--square">
-    <div class="van-cell van-cell--borderless van-field">
-      <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-          <!----></i></div>
-      <div class="van-cell__value van-cell__value--alone">
-        <div class="van-field__body"><input type="search" class="van-field__control"></div>
+<form action="/">
+  <div class="van-search van-search--show-action" style="background: rgb(255, 255, 255);">
+    <div class="van-search__content van-search__content--square">
+      <div class="van-cell van-cell--borderless van-field">
+        <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+            <!----></i></div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-field__body"><input type="search" class="van-field__control"></div>
+        </div>
       </div>
     </div>
+    <div role="button" tabindex="0" class="van-search__action">Custom Text</div>
   </div>
-  <div role="button" tabindex="0" class="van-search__action">Custom Text</div>
-</div>
+</form>
 `;
 
 exports[`label slot 1`] = `
-<div class="van-search" style="background: rgb(255, 255, 255);">
-  <div class="van-search__content van-search__content--square">
-    <div class="van-search__label">Custom Label</div>
-    <div class="van-cell van-cell--borderless van-field">
-      <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-          <!----></i></div>
-      <div class="van-cell__value van-cell__value--alone">
-        <div class="van-field__body"><input type="search" class="van-field__control"></div>
+<form action="/">
+  <div class="van-search" style="background: rgb(255, 255, 255);">
+    <div class="van-search__content van-search__content--square">
+      <div class="van-search__label">Custom Label</div>
+      <div class="van-cell van-cell--borderless van-field">
+        <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+            <!----></i></div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-field__body"><input type="search" class="van-field__control"></div>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</form>
 `;
 
 exports[`left-icon prop 1`] = `
-<div class="van-search" style="background: rgb(255, 255, 255);">
-  <div class="van-search__content van-search__content--square">
-    <div class="van-cell van-cell--borderless van-field">
-      <div class="van-field__left-icon"><i class="van-icon van-icon-setting-o">
-          <!----></i></div>
-      <div class="van-cell__value van-cell__value--alone">
-        <div class="van-field__body"><input type="search" class="van-field__control"></div>
+<form action="/">
+  <div class="van-search" style="background: rgb(255, 255, 255);">
+    <div class="van-search__content van-search__content--square">
+      <div class="van-cell van-cell--borderless van-field">
+        <div class="van-field__left-icon"><i class="van-icon van-icon-setting-o">
+            <!----></i></div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-field__body"><input type="search" class="van-field__control"></div>
+        </div>
       </div>
     </div>
   </div>
-</div>
+</form>
 `;
 
 exports[`right-icon prop 1`] = `
-<div class="van-search" style="background: rgb(255, 255, 255);">
-  <div class="van-search__content van-search__content--square">
-    <div class="van-cell van-cell--borderless van-field">
-      <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-          <!----></i></div>
-      <div class="van-cell__value van-cell__value--alone">
-        <div class="van-field__body"><input type="search" class="van-field__control">
-          <div class="van-field__right-icon"><i class="van-icon van-icon-setting-o">
-              <!----></i></div>
+<form action="/">
+  <div class="van-search" style="background: rgb(255, 255, 255);">
+    <div class="van-search__content van-search__content--square">
+      <div class="van-cell van-cell--borderless van-field">
+        <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+            <!----></i></div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-field__body"><input type="search" class="van-field__control">
+            <div class="van-field__right-icon"><i class="van-icon van-icon-setting-o">
+                <!----></i></div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</form>
 `;
 
 exports[`right-icon slot 1`] = `
-<div class="van-search" style="background: rgb(255, 255, 255);">
-  <div class="van-search__content van-search__content--square">
-    <div class="van-cell van-cell--borderless van-field">
-      <div class="van-field__left-icon"><i class="van-icon van-icon-search">
-          <!----></i></div>
-      <div class="van-cell__value van-cell__value--alone">
-        <div class="van-field__body"><input type="search" class="van-field__control">
-          <div class="van-field__right-icon">Custom Right Icon</div>
+<form action="/">
+  <div class="van-search" style="background: rgb(255, 255, 255);">
+    <div class="van-search__content van-search__content--square">
+      <div class="van-cell van-cell--borderless van-field">
+        <div class="van-field__left-icon"><i class="van-icon van-icon-search">
+            <!----></i></div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-field__body"><input type="search" class="van-field__control">
+            <div class="van-field__right-icon">Custom Right Icon</div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+</form>
 `;


### PR DESCRIPTION
## Why
With iOS, it will apply developer nest this component in a `form` tag to get 「search」return button in keyboard. This enhancement lets us implement it call the component without extra next HTML element.

## How
Show in the pr code review.

## Test
### Before
- run `yarn test`
![test-before](https://user-images.githubusercontent.com/27187946/67542197-6eb5d280-f71e-11e9-98b4-d438e4670584.jpg)

- runtime case
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27187946/67542206-77a6a400-f71e-11e9-9566-4545e2016853.gif)

### After
- run `yarn test`
![test-after](https://user-images.githubusercontent.com/27187946/67542179-5cd42f80-f71e-11e9-89e4-b712e1948ace.jpg)

- runtime case
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/27187946/67542188-66f62e00-f71e-11e9-837b-bb0b7324a1bd.gif)




