### PR TITLE
feat(address-list)!: 添加 `设为默认` 按钮

### DIFF
--- a/src/address-list/Item.tsx
+++ b/src/address-list/Item.tsx
@@ -87,7 +87,6 @@ function AddressItem(
   return (
     <Cell
       class={bem({ disabled })}
-      valueClass={bem('value')}
       clickable={!disabled}
       scopedSlots={{
         default: renderContent

--- a/src/address-list/Item.tsx
+++ b/src/address-list/Item.tsx
@@ -18,14 +18,13 @@ export type AddressItemData = {
 export type AddressItemProps = {
   data: AddressItemData;
   disabled?: boolean;
-  switchable?: boolean;
 };
 
 export type AddressItemEvents = {
   onEdit(): void;
   onClick(): void;
-  onSelect(): void;
   onDelete(): void;
+  onDefault(): void;
 };
 
 const [createComponent, bem] = createNamespace('address-item');
@@ -36,67 +35,63 @@ function AddressItem(
   slots: DefaultSlots,
   ctx: RenderContext<AddressItemProps>
 ) {
-  const { disabled, switchable } = props;
+  const { disabled } = props;
 
   function onClick() {
-    if (switchable) {
-      emit(ctx, 'select');
-    }
-
     emit(ctx, 'click');
+  }
+
+  function onSetDefault() {
+    emit(ctx, 'default');
   }
 
   const renderRightIcon = () => (
     <div class={bem('icons-wrapper')}>
-      <span class={bem('icons-group')}>
-        <Icon
-          name="edit"
-          class={bem('edit')}
-          onClick={(event: Event) => {
-            event.stopPropagation();
-            emit(ctx, 'edit');
-            emit(ctx, 'click');
-          }}
-        />
-        <Icon
-          name="delete"
-          class={bem('delete')}
-          onClick={(event: Event) => {
-            event.stopPropagation();
-            emit(ctx, 'delete');
-            emit(ctx, 'click');
-          }}
-        />
-      </span>
+      <Icon
+        name="edit"
+        class={bem('edit')}
+        onClick={(event: Event) => {
+          event.stopPropagation();
+          emit(ctx, 'edit');
+        }}
+      />
+      <Icon
+        name="delete"
+        class={bem('delete')}
+        onClick={(event: Event) => {
+          event.stopPropagation();
+          emit(ctx, 'delete');
+        }}
+      />
     </div>
   );
 
   const renderContent = () => {
     const { data } = props;
     const Info = [
-      <div class={bem('name')}>{`${data.name}，${data.tel}`}</div>,
-      <div class={bem('address')}>{data.address}</div>
+      <div onClick={onClick}>
+        <div class={bem('name')}>{`${data.name}，${data.tel}`}</div>
+        <div class={bem('address')}>{data.address}</div>
+      </div>,
+      <div class={bem('bar')}>
+        <Radio name={data.id} onClick={onSetDefault} class={bem('set-default')}>
+          设为默认
+        </Radio>
+        {renderRightIcon()}
+      </div>
     ];
 
-    return switchable && !disabled ? (
-      <Radio name={data.id} iconSize={16}>
-        {Info}
-      </Radio>
-    ) : (
-      Info
-    );
+    return Info;
   };
 
   return (
     <Cell
       class={bem({ disabled })}
       valueClass={bem('value')}
-      clickable={switchable && !disabled}
+      clickable={!disabled}
       scopedSlots={{
-        default: renderContent,
-        'right-icon': renderRightIcon
+        default: renderContent
       }}
-      onClick={onClick}
       {...inherit(ctx)}
     />
   );
@@ -105,7 +100,6 @@ function AddressItem(
 AddressItem.props = {
   data: Object,
   disabled: Boolean,
-  switchable: Boolean
 };
 
 export default createComponent<AddressItemProps, AddressItemEvents>(AddressItem);

--- a/src/address-list/Item.tsx
+++ b/src/address-list/Item.tsx
@@ -69,7 +69,7 @@ function AddressItem(
   const renderContent = () => {
     const { data } = props;
     const Info = [
-      <div onClick={onClick}>
+      <div class={bem('content')} onClick={onClick}>
         <div class={bem('name')}>{`${data.name}，${data.tel}`}</div>
         <div class={bem('address')}>{data.address}</div>
       </div>,

--- a/src/address-list/README.zh-CN.md
+++ b/src/address-list/README.zh-CN.md
@@ -22,6 +22,7 @@ Vue.use(AddressList);
   @add="onAdd"
   @edit="onEdit"
   @delete="onDelete"
+  @set-default="onSetDefault"
 />
 ```
 
@@ -66,6 +67,10 @@ export default {
 
     onDelete(item, index) {
       Toast('删除地址:' + index)
+    },
+
+    onSetDefault(item, index) {
+      Toast('设为默认地址', index)
     }
   }
 }
@@ -81,7 +86,6 @@ export default {
 | list | 地址列表 | *Address[]* | `[]` | - |
 | disabled-list | 不可配送地址列表 | *Address[]* | `[]` | - |
 | disabled-text | 不可配送提示文案 | *string* | - | - |
-| switchable | 是否允许切换地址 | *boolean* | `true` | - |
 | add-button-text | 底部按钮文字 | *string* | `新增地址` | - |
 
 ### Events
@@ -95,6 +99,7 @@ export default {
 | edit-disabled | 编辑不可配送的地址时触发 | item: 地址对象，index: 索引 |
 | select-disabled | 选中不可配送的地址时触发 | item: 地址对象，index: 索引 |
 | click-item | 点击任意地址时触发 | item: 地址对象，index: 索引 |
+| set-default | 点击设为默认时触发 | item: 地址对象，index: 索引 |
 
 ### Address 数据结构
 

--- a/src/address-list/demo/index.vue
+++ b/src/address-list/demo/index.vue
@@ -9,6 +9,8 @@
         @add="onAdd"
         @edit="onEdit"
         @delete="onDelete"
+        @click-item="onClick"
+        @set-default="onSetDefault"
       />
     </demo-block>
   </demo-section>
@@ -90,6 +92,14 @@ export default {
 
     onDelete(item, index) {
       this.$toast(`${this.$t('delete')}:${index}`);
+    },
+
+    onClick(item, index) {
+      console.log('on click', item, index);
+    },
+
+    onSetDefault(item, index) {
+      console.log('on set default', item, index);
     }
   }
 };

--- a/src/address-list/demo/index.vue
+++ b/src/address-list/demo/index.vue
@@ -95,11 +95,11 @@ export default {
     },
 
     onClick(item, index) {
-      console.log('on click', item, index);
+      this.$toast(`点击:${index}`);
     },
 
     onSetDefault(item, index) {
-      console.log('on set default', item, index);
+      this.$toast(`设为默认:${index}`);
     }
   }
 };

--- a/src/address-list/index.less
+++ b/src/address-list/index.less
@@ -23,10 +23,6 @@
 .van-address-item {
   padding: @address-list-item-padding;
 
-  &__value {
-    padding-right: @padding-xl;
-  }
-
   &__name {
     margin-bottom: @padding-base;
     font-weight: @font-weight-bold;
@@ -40,23 +36,28 @@
     line-height: @address-list-item-line-height;
   }
 
-  &--disabled {
-    .van-address-item__name,
-    .van-address-item__address {
-      color: @address-list-item-disabled-text-color;
-    }
+  &__bar {
+    display: flex;
+    padding-top: 10px;
+  }
+
+  &__set-default {
+    flex: 1;
   }
 
   &__icons-wrapper {
-    margin-left: @padding-md;
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+    font-size: @address-list-edit-icon-size;
   }
 
-  &__icons-group {
-    position: absolute;
-    top: 50%;
-    right: @padding-md;
-    font-size: @address-list-edit-icon-size;
-    transform: translate(0, -50%);
+  &--disabled {
+    .van-address-item__name,
+    .van-address-item__address,
+    .van-address-item__set-default .van-radio__label {
+      color: @address-list-item-disabled-text-color;
+    }
   }
 
   &__edit {

--- a/src/address-list/index.tsx
+++ b/src/address-list/index.tsx
@@ -10,7 +10,6 @@ import { ScopedSlot, DefaultSlots } from '../utils/types';
 
 export type AddressListProps = {
   value?: string | number;
-  switchable: boolean;
   disabledText?: string;
   addButtonText?: string;
   list?: AddressItemData[];
@@ -39,14 +38,6 @@ function AddressList(
         data={item}
         key={item.id}
         disabled={disabled}
-        switchable={props.switchable}
-        onSelect={() => {
-          emit(ctx, disabled ? 'select-disabled' : 'select', item, index);
-
-          if (!disabled) {
-            emit(ctx, 'input', item.id);
-          }
-        }}
         onEdit={() => {
           emit(ctx, disabled ? 'edit-disabled' : 'edit', item, index);
         }}
@@ -55,6 +46,13 @@ function AddressList(
         }}
         onDelete={() => {
           emit(ctx, 'delete', item, index);
+        }}
+        onDefault={() => {
+          emit(ctx, disabled ? 'set-default-disabled' : 'set-default', item, index);
+
+          if (!disabled) {
+            emit(ctx, 'input', item.id);
+          }
         }}
       />
     ));
@@ -89,11 +87,7 @@ AddressList.props = {
   disabledList: Array,
   disabledText: String,
   addButtonText: String,
-  value: [Number, String],
-  switchable: {
-    type: Boolean,
-    default: true
-  }
+  value: [Number, String]
 };
 
 export default createComponent<AddressListProps>(AddressList);

--- a/src/address-list/test/__snapshots__/demo.spec.js.snap
+++ b/src/address-list/test/__snapshots__/demo.spec.js.snap
@@ -6,31 +6,57 @@ exports[`renders demo correctly 1`] = `
     <div class="van-address-list">
       <div role="radiogroup" class="van-radio-group">
         <div role="button" tabindex="0" class="van-cell van-cell--clickable van-address-item">
-          <div class="van-cell__value van-cell__value--alone van-address-item__value">
-            <div role="radio" tabindex="0" aria-checked="true" class="van-radio">
-              <div class="van-radio__icon van-radio__icon--round van-radio__icon--checked" style="font-size: 16px;"><i class="van-icon van-icon-success">
-                  <!----></i></div><span class="van-radio__label"><div class="van-address-item__name">张三，13000000000</div><div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div></span>
+          <div class="van-cell__value van-cell__value--alone">
+            <div class="van-address-item__content">
+              <div class="van-address-item__name">张三，13000000000</div>
+              <div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div>
+            </div>
+            <div class="van-address-item__bar">
+              <div role="radio" tabindex="0" aria-checked="true" class="van-radio van-address-item__set-default">
+                <div class="van-radio__icon van-radio__icon--round van-radio__icon--checked"><i class="van-icon van-icon-success">
+                    <!----></i></div><span class="van-radio__label">设为默认</span>
+              </div>
+              <div class="van-address-item__icons-wrapper"><i class="van-icon van-icon-edit van-address-item__edit">
+                  <!----></i><i class="van-icon van-icon-delete van-address-item__delete">
+                  <!----></i></div>
             </div>
           </div>
-          <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
         </div>
         <div role="button" tabindex="0" class="van-cell van-cell--clickable van-address-item">
-          <div class="van-cell__value van-cell__value--alone van-address-item__value">
-            <div role="radio" tabindex="-1" aria-checked="false" class="van-radio">
-              <div class="van-radio__icon van-radio__icon--round" style="font-size: 16px;"><i class="van-icon van-icon-success">
-                  <!----></i></div><span class="van-radio__label"><div class="van-address-item__name">李四，1310000000</div><div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div></span>
+          <div class="van-cell__value van-cell__value--alone">
+            <div class="van-address-item__content">
+              <div class="van-address-item__name">李四，1310000000</div>
+              <div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div>
+            </div>
+            <div class="van-address-item__bar">
+              <div role="radio" tabindex="-1" aria-checked="false" class="van-radio van-address-item__set-default">
+                <div class="van-radio__icon van-radio__icon--round"><i class="van-icon van-icon-success">
+                    <!----></i></div><span class="van-radio__label">设为默认</span>
+              </div>
+              <div class="van-address-item__icons-wrapper"><i class="van-icon van-icon-edit van-address-item__edit">
+                  <!----></i><i class="van-icon van-icon-delete van-address-item__delete">
+                  <!----></i></div>
             </div>
           </div>
-          <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
         </div>
       </div>
       <div class="van-address-list__disabled-text">以下地址超出配送范围</div>
       <div class="van-cell van-address-item van-address-item--disabled">
-        <div class="van-cell__value van-cell__value--alone van-address-item__value">
-          <div class="van-address-item__name">王五，1320000000</div>
-          <div class="van-address-item__address">浙江省杭州市滨江区江南大道 15 号</div>
+        <div class="van-cell__value van-cell__value--alone">
+          <div class="van-address-item__content">
+            <div class="van-address-item__name">王五，1320000000</div>
+            <div class="van-address-item__address">浙江省杭州市滨江区江南大道 15 号</div>
+          </div>
+          <div class="van-address-item__bar">
+            <div role="radio" tabindex="-1" aria-checked="false" class="van-radio van-address-item__set-default">
+              <div class="van-radio__icon van-radio__icon--round"><i class="van-icon van-icon-success">
+                  <!----></i></div><span class="van-radio__label">设为默认</span>
+            </div>
+            <div class="van-address-item__icons-wrapper"><i class="van-icon van-icon-edit van-address-item__edit">
+                <!----></i><i class="van-icon van-icon-delete van-address-item__delete">
+                <!----></i></div>
+          </div>
         </div>
-        <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
       </div><button class="van-button van-button--danger van-button--large van-button--square van-address-list__add"><span class="van-button__text">新增地址</span></button>
     </div>
   </div>

--- a/src/address-list/test/__snapshots__/index.spec.js.snap
+++ b/src/address-list/test/__snapshots__/index.spec.js.snap
@@ -3,19 +3,39 @@
 exports[`unswitchable 1`] = `
 <div class="van-address-list">
   <div role="radiogroup" class="van-radio-group">
-    <div class="van-cell van-address-item">
-      <div class="van-cell__value van-cell__value--alone van-address-item__value">
-        <div class="van-address-item__name">张三，13000000000</div>
-        <div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div>
+    <div role="button" tabindex="0" class="van-cell van-cell--clickable van-address-item">
+      <div class="van-cell__value van-cell__value--alone">
+        <div class="van-address-item__content">
+          <div class="van-address-item__name">张三，13000000000</div>
+          <div class="van-address-item__address">浙江省杭州市西湖区文三路 138 号东方通信大厦 7 楼 501 室</div>
+        </div>
+        <div class="van-address-item__bar">
+          <div role="radio" tabindex="-1" aria-checked="false" class="van-radio van-address-item__set-default">
+            <div class="van-radio__icon van-radio__icon--round"><i class="van-icon van-icon-success">
+                <!----></i></div><span class="van-radio__label">设为默认</span>
+          </div>
+          <div class="van-address-item__icons-wrapper"><i class="van-icon van-icon-edit van-address-item__edit">
+              <!----></i><i class="van-icon van-icon-delete van-address-item__delete">
+              <!----></i></div>
+        </div>
       </div>
-      <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
     </div>
-    <div class="van-cell van-address-item">
-      <div class="van-cell__value van-cell__value--alone van-address-item__value">
-        <div class="van-address-item__name">李四，1310000000</div>
-        <div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div>
+    <div role="button" tabindex="0" class="van-cell van-cell--clickable van-address-item">
+      <div class="van-cell__value van-cell__value--alone">
+        <div class="van-address-item__content">
+          <div class="van-address-item__name">李四，1310000000</div>
+          <div class="van-address-item__address">浙江省杭州市拱墅区莫干山路 50 号</div>
+        </div>
+        <div class="van-address-item__bar">
+          <div role="radio" tabindex="-1" aria-checked="false" class="van-radio van-address-item__set-default">
+            <div class="van-radio__icon van-radio__icon--round"><i class="van-icon van-icon-success">
+                <!----></i></div><span class="van-radio__label">设为默认</span>
+          </div>
+          <div class="van-address-item__icons-wrapper"><i class="van-icon van-icon-edit van-address-item__edit">
+              <!----></i><i class="van-icon van-icon-delete van-address-item__delete">
+              <!----></i></div>
+        </div>
       </div>
-      <div class="van-address-item__icons-wrapper"><span class="van-address-item__icons-group"><i class="van-icon van-icon-edit van-address-item__edit"><!----></i><i class="van-icon van-icon-delete van-address-item__delete"><!----></i></span></div>
     </div>
   </div><button class="van-button van-button--danger van-button--large van-button--square van-address-list__add"><span class="van-button__text">新增地址</span></button>
 </div>

--- a/src/address-list/test/index.spec.js
+++ b/src/address-list/test/index.spec.js
@@ -27,22 +27,22 @@ test('unswitchable', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
-test('select event', () => {
-  const onSelect = jest.fn();
+test('set default event', () => {
+  const onDefault = jest.fn();
   const wrapper = mount(AddressList, {
     propsData: {
       list
     },
     context: {
       on: {
-        select: onSelect
+        'set-default': onDefault
       }
     }
   });
 
   wrapper.find('.van-radio__icon').trigger('click');
 
-  expect(onSelect).toHaveBeenCalledTimes(1);
+  expect(onDefault).toHaveBeenCalledTimes(1);
 });
 
 test('click-item event', () => {
@@ -58,7 +58,7 @@ test('click-item event', () => {
     }
   });
 
-  wrapper.find('.van-address-item').trigger('click');
+  wrapper.find('.van-address-item__content').trigger('click');
 
   expect(onClickItem).toHaveBeenCalledTimes(1);
 });


### PR DESCRIPTION
## Why

- 业务场景需求以及先前成功案例, 促使这次变更.

## How

1. 删除 默认侧边 ☑️ 按钮
2. 改由下方添加一个 ☑️设为默认 按钮
3. 变更点击逻辑/事件 (回调数据是 当前地址数据(item: object, index: number))
3.1 点击地址主体内容 `@click-item`
3.2 点击 设为默认 按钮 `@set-default`
4. 调整样式, 功能归纳在下方(见图)

## NEW

### `@set-default`

- Type: `(item: AddressInfo, index: Number) => void`

## BREAK

### `props.switchable`

### `@select`

## GIF

![address-default](https://user-images.githubusercontent.com/53422750/67553776-8605b780-f740-11e9-9be3-61a120c68291.gif)

#### 屏幕截图

运行 eslint 屏幕截图

```console
$ eslint ./src --ext .js,.vue,.ts,.tsx --fix && stylelint "src/**/*.less" --fix
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree.

You may find that it works just fine, or you may not.

SUPPORTED TYPESCRIPT VERSIONS: >=3.2.1 <3.6.0

YOUR TYPESCRIPT VERSION: 3.6.3

Please only submit bug reports when using the officially supported version.

=============
✨  Done in 76.34s.
```

运行 test 屏幕截图

![image](https://user-images.githubusercontent.com/53422750/67551643-fe1dae80-f73b-11e9-82d8-1d16437379e3.png)
