### PR TITLE
fix(select): overlay propagation

### DIFF
--- a/src/overlay/index.tsx
+++ b/src/overlay/index.tsx
@@ -1,6 +1,6 @@
 import { createNamespace, isDef } from '../utils';
 import { inherit } from '../utils/functional';
-import { preventDefault } from '../utils/dom/event';
+import { preventDefault, stopPropagation } from '../utils/dom/event';
 
 // Types
 import { CreateElement, RenderContext } from 'vue/types';
@@ -46,6 +46,7 @@ function Overlay(
         style={style}
         class={[bem(), props.className]}
         onTouchmove={preventTouchMove}
+        onClick={stopPropagation}
         {...inherit(ctx, true)}
       >
         {slots.default && slots.default()}

--- a/src/select/index.js
+++ b/src/select/index.js
@@ -57,7 +57,7 @@ export default createComponent({
           {this.slots(slotName)}
         </template>
       ));
-    }
+    },
   },
 
   render() {
@@ -78,9 +78,6 @@ export default createComponent({
           onSelect={this.onSelect}
           value={this.showSheet}
           actions={this.options}
-          // FIXME: 如果开启点击遮罩，会导致点击遮罩冒泡到 field 的 click 事件，导致再次打开 actionSheet
-          // onClickOverlay={stopPropagation}
-          closeOnClickOverlay={false}
           closeOnClickAction={true}
           onInput={this.triggle}
         />


### PR DESCRIPTION
## Why

因为 Vant 的遮罩没有阻止事件冒泡，导致 select 的 click 事件也被触发
当 `closeOnClickOverlay` 为 `true` 时，关闭了遮罩又被 triggle 打开

## How
Overlay 组件点击事件增加阻止冒泡

## Test
### Before
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27187946/68100204-b2b88c80-ff01-11e9-8898-4d667c2d256c.gif)

### After
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/27187946/68100246-f9a68200-ff01-11e9-9d61-43f43d690645.gif)

### Eslint
![eslint](https://user-images.githubusercontent.com/27187946/68100253-032fea00-ff02-11e9-80a2-a3d7356ff561.jpg)

### Snapshot Test
![test](https://user-images.githubusercontent.com/27187946/68100264-12169c80-ff02-11e9-8355-a930f6815d82.jpg)

