### PR TITLE
chore(deps): move some deps to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "author": "youzanfe",
   "license": "MIT",
   "dependencies": {
+    "@babel/runtime": "7.x",
     "@vant/icons": "1.1.14",
     "vue-lazyload": "1.2.3"
   },
@@ -72,7 +73,6 @@
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.2",
     "@babel/preset-typescript": "^7.6.0",
-    "@babel/runtime": "7.x",
     "@types/jest": "^24.0.16",
     "@vant/cli": "^1.0.6",
     "@vant/doc": "^2.5.7",

--- a/package.json
+++ b/package.json
@@ -53,9 +53,7 @@
   "author": "youzanfe",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "7.x",
     "@vant/icons": "1.1.14",
-    "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "vue-lazyload": "1.2.3"
   },
   "peerDependencies": {
@@ -70,6 +68,7 @@
     "@babel/polyfill": "^7.6.0",
     "@babel/preset-env": "^7.6.2",
     "@babel/preset-typescript": "^7.6.0",
+    "@babel/runtime": "7.x",
     "@types/jest": "^24.0.16",
     "@vant/cli": "^1.0.6",
     "@vant/doc": "^2.5.7",
@@ -77,6 +76,7 @@
     "@vant/markdown-loader": "^2.2.0",
     "@vant/markdown-vetur": "^1.0.0",
     "@vant/touch-emulator": "^1.1.0",
+    "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
     "@vue/babel-preset-jsx": "^1.1.0",
     "@vue/test-utils": "^1.0.0-beta.29",
     "autoprefixer": "^9.6.1",


### PR DESCRIPTION
有必要啊! 开发依赖不需要作为依赖被共同下载到项目.